### PR TITLE
Add --SKIPIF-- section support

### DIFF
--- a/src/PsalmTest.php
+++ b/src/PsalmTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
  */
 final readonly class PsalmTest
 {
+    private const SKIPIF = 'SKIPIF';
     private const FILE = 'FILE';
     private const ARGS = 'ARGS';
     private const EXPECT = 'EXPECT';
@@ -49,6 +50,56 @@ final readonly class PsalmTest
             arguments: $sections[self::ARGS][0] ?? '',
             codeFirstLine: $sections[self::FILE][1],
         );
+    }
+
+    /**
+     * Evaluate the --SKIPIF-- section of a .phpt file and return the skip reason,
+     * or null if the test should not be skipped.
+     *
+     * The SKIPIF section contains a PHP script (starting with <?php) that echoes
+     * a message beginning with "skip" when the test should be skipped, e.g.:
+     *
+     *   --SKIPIF--
+     *   <?php if (PHP_VERSION_ID < 80200) { echo 'skip requires PHP 8.2+'; }
+     *
+     * Returns null when no SKIPIF section is present or when the section's output
+     * does not start with "skip".
+     */
+    public static function getSkipReason(string $phptFile): ?string
+    {
+        $sections = self::parsePhpt($phptFile);
+
+        if (!isset($sections[self::SKIPIF])) {
+            return null;
+        }
+
+        // Write the SKIPIF code to a temp file so that require handles <?php correctly.
+        $tempFile = \tempnam(\sys_get_temp_dir(), 'psalm_skipif_');
+
+        if ($tempFile === false) {
+            return null;
+        }
+
+        \file_put_contents($tempFile, $sections[self::SKIPIF][0]);
+
+        \ob_start();
+
+        try {
+            // Isolate the require to avoid polluting the current scope.
+            (static function (string $file): void {
+                require $file;
+            })($tempFile);
+        } finally {
+            \unlink($tempFile);
+        }
+
+        $output = \trim(\ob_get_clean() ?: '');
+
+        if (\stripos($output, 'skip') === 0) {
+            return $output;
+        }
+
+        return null;
     }
 
     /**

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -56,31 +56,144 @@ final readonly class PsalmTester
         return $temporaryDirectory;
     }
 
+    /**
+     * Run multiple tests in batched Psalm invocations (one per unique argument set).
+     * Returns formatted output per test — callers are responsible for assertions.
+     * @api
+     * @param array<string, PsalmTest> $tests keyed by identifier
+     * @return array<string, string> formatted output keyed by identifier
+     */
+    public function runBatch(array $tests): array
+    {
+        /** @var array<string, array<string, array{file: string, test: PsalmTest}>> */
+        $groups = [];
+
+        foreach ($tests as $id => $test) {
+            $args = $test->arguments ?: $this->defaultArguments;
+            $groups[$args][$id] = [
+                'file' => $this->createTemporaryCodeFile($test->code),
+                'test' => $test,
+            ];
+        }
+
+        $results = [];
+
+        foreach ($groups as $args => $entries) {
+            $results += $this->runGroup($args, $entries);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array<string, array{file: string, test: PsalmTest}> $entries
+     * @return array<string, string>
+     */
+    private function runGroup(string $args, array $entries): array
+    {
+        try {
+            $filePaths = array_map(
+                static fn(array $entry): string => $entry['file'],
+                $entries,
+            );
+
+            $output = $this->runPsalm($args, ...array_values($filePaths));
+            $decoded = $this->decodeOutput($output, $args);
+
+            /** @var array<string, list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}>> $errorsByFile */
+            $errorsByFile = [];
+            foreach ($decoded as $error) {
+                $errorsByFile[$error['file_path']][] = $error;
+            }
+
+            return array_map(function ($entry) use ($errorsByFile) {
+                return $this->formatErrors(
+                    $errorsByFile[$entry['file']] ?? [],
+                    $entry['test']->codeFirstLine,
+                );
+            }, $entries);
+        } finally {
+            foreach ($entries as $entry) {
+                @unlink($entry['file']);
+            }
+        }
+    }
+
     public function test(PsalmTest $test): void
     {
         $codeFile = $this->createTemporaryCodeFile($test->code);
 
         try {
-            $command = \sprintf(
-                '%s --output-format=json %s %s',
-                $this->psalmPath,
-                $test->arguments ?: $this->defaultArguments,
-                $codeFile,
-            );
-
-            /** @psalm-suppress ForbiddenCode */
-            $output = shell_exec($command);
-
-            if (!\is_string($output)) {
-                throw new \RuntimeException(\sprintf('Failed to run command %s.', $command));
-            }
-
-            $formattedOutput = $this->formatOutput($output, $test->codeFirstLine);
+            $args = $test->arguments ?: $this->defaultArguments;
+            $output = $this->runPsalm($args, $codeFile);
+            $decoded = $this->decodeOutput($output, $args);
+            $formattedOutput = $this->formatErrors($decoded, $test->codeFirstLine);
 
             Assert::assertThat($formattedOutput, $test->constraint);
         } finally {
             @unlink($codeFile);
         }
+    }
+
+    /**
+     * @param string $args Pre-built argument string — trusted input from $this->defaultArguments or PsalmTest::$arguments (parsed from .phpt files).
+     *                     Not escaped, as it contains multiple shell-level arguments.
+     */
+    private function runPsalm(string $args, string ...$files): string
+    {
+        $command = \sprintf(
+            '%s --output-format=json %s %s',
+            escapeshellarg($this->psalmPath),
+            $args,
+            implode(' ', array_map(escapeshellarg(...), $files)),
+        );
+
+        /** @psalm-suppress ForbiddenCode */
+        $output = shell_exec($command);
+
+        if (!\is_string($output)) {
+            throw new \RuntimeException(\sprintf('Failed to run command %s.', $command));
+        }
+
+        return $output;
+    }
+
+    /**
+     * @return list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}>
+     */
+    private function decodeOutput(string $output, string $args): array
+    {
+        try {
+            /** @var list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}> */
+            return json_decode($output, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(\sprintf(
+                "Failed to decode Psalm JSON output for args [%s]: %s\nOutput: %s",
+                $args,
+                $e->getMessage(),
+                $output,
+            ), previous: $e);
+        }
+    }
+
+    /**
+     * @param list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}> $errors
+     * @param positive-int $codeFirstLine
+     */
+    private function formatErrors(array $errors, int $codeFirstLine): string
+    {
+        /** @psalm-suppress PossiblyUndefinedStringArrayOffset */
+        usort($errors, static fn(array $a, array $b): int => $a['line_from'] <=> $b['line_from']);
+
+        return implode("\n", array_map(
+            static fn(array $error): string => \sprintf(
+                '%s on line %d: %s',
+                $error['type'],
+                $error['line_from'] + $codeFirstLine - 1,
+                $error['message'],
+            ),
+            $errors,
+        ));
     }
 
     private function createTemporaryCodeFile(string $contents): string
@@ -94,21 +207,5 @@ final readonly class PsalmTester
         file_put_contents($file, $contents);
 
         return $file;
-    }
-
-    private function formatOutput(string $output, int $codeFirstLine): string
-    {
-        /** @var list<array{type: string, column_from: int, line_from: int, message: string, ...}> */
-        $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
-
-        return implode("\n", array_map(
-            static fn(array $error): string => \sprintf(
-                '%s on line %d: %s',
-                $error['type'],
-                $error['line_from'] + $codeFirstLine - 1,
-                $error['message'],
-            ),
-            $decoded,
-        ));
     }
 }

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -16,17 +16,20 @@ final readonly class PsalmTester
         private string $psalmPath,
         private string $defaultArguments,
         private string $temporaryDirectory,
+        private bool $showProgress,
     ) {}
 
     public static function create(
         ?string $psalmPath = null,
         string $defaultArguments = '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
         ?string $temporaryDirectory = null,
+        bool $showProgress = true,
     ): self {
         return new self(
             psalmPath: $psalmPath ?? self::findPsalm(),
             defaultArguments: $defaultArguments,
             temporaryDirectory: self::resolveTemporaryDirectory($temporaryDirectory),
+            showProgress: $showProgress,
         );
     }
 
@@ -79,7 +82,9 @@ final readonly class PsalmTester
         $results = [];
 
         foreach ($groups as $args => $entries) {
-            $results += $this->runGroup($args, $entries);
+            $groupResults = $this->runGroup($args, $entries);
+            $this->writeProgress(\count($groupResults));
+            $results += $groupResults;
         }
 
         return $results;
@@ -130,6 +135,7 @@ final readonly class PsalmTester
             $formattedOutput = $this->formatErrors($decoded, $test->codeFirstLine);
 
             Assert::assertThat($formattedOutput, $test->constraint);
+            $this->writeProgress(1);
         } finally {
             @unlink($codeFile);
         }
@@ -194,6 +200,13 @@ final readonly class PsalmTester
             ),
             $errors,
         ));
+    }
+
+    private function writeProgress(int $count): void
+    {
+        if ($this->showProgress) {
+            fwrite(\STDERR, str_repeat('.', $count));
+        }
     }
 
     private function createTemporaryCodeFile(string $contents): string


### PR DESCRIPTION
## Summary

Adds standard PHPT `--SKIPIF--` section support so tests can declare conditions under which they should be skipped.

## New API

**`PsalmTest::getSkipReason(string $phptFile): ?string`**

Evaluates the `--SKIPIF--` PHP script and returns the skip reason if the output starts with `"skip"`, or `null` otherwise. Mirrors how PHP's own PHPT test runner handles skip conditions.

## Usage

```phpt
--SKIPIF--
<?php if (version_compare(\Illuminate\Foundation\Application::VERSION, '12.0.0', '<')) {
    echo 'skip requires Laravel 12+';
}
--FILE--
<?php declare(strict_types=1);
// ...
--EXPECTF--
// ...
```

In your PHPUnit test class:

```php
public static function setUpBeforeClass(): void
{
    foreach (self::discoverPhptFiles($baseDir) as $absPath => $relPath) {
        $skipReason = PsalmTest::getSkipReason($absPath);
        if ($skipReason !== null) {
            self::$skipReasons[$relPath] = $skipReason;
            continue;
        }
        self::$testData[$relPath] = PsalmTest::fromPhptFile($absPath);
    }
    // ...
}

public function testPhptFiles(string $relPath): void
{
    if (isset(self::$skipReasons[$relPath])) {
        $this->markTestSkipped(self::$skipReasons[$relPath]);
    }
    // ...
}
```

## Design notes

- The `SKIPIF` constant is added so the parser accepts the section without throwing `InvalidArgumentException`.
- The SKIPIF code is written to a temp file and `require`d so that the `<?php` tag is handled correctly.
- `fromPhptFile()` itself is unchanged — callers check `getSkipReason()` first and skip the `fromPhptFile()` call when appropriate.
