### PR TITLE
Add batch execution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ final class MyPsalmTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         $tester = PsalmTester::create(
-            defaultArguments: '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
+            defaultArguments: '--no-progress --no-diff --config=' . dirname(__DIR__) . '/psalm.xml',
         );
 
         foreach (self::discoverPhptFiles() as $name => $path) {

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Trace on line %d: $_list: non-empty-list<%s>
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use PHPyh\PsalmTester\PsalmTester;
-use PHPyh\PsalmTester\StaticAnalysisTest;
+use PHPyh\PsalmTester\PsalmTest as PsalmTestFixture;
 
-final class PsalmTest extends TestCase
+final class MyPsalmTest extends TestCase
 {
     private ?PsalmTester $psalmTester = null;
 
@@ -57,7 +57,7 @@ final class PsalmTest extends TestCase
     public function testPhptFiles(string $phptFile): void
     {
         $this->psalmTester ??= PsalmTester::create();
-        $this->psalmTester->test(StaticAnalysisTest::fromPhptFile($phptFile));
+        $this->psalmTester->test(PsalmTestFixture::fromPhptFile($phptFile));
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -107,25 +107,80 @@ In your test suite, call `PsalmTest::getSkipReason()` before loading the test an
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use PHPyh\PsalmTester\PsalmTester;
-use PHPyh\PsalmTester\PsalmTest;
+use PHPyh\PsalmTester\PsalmTest as PsalmTestFixture;
 
-final class PsalmTest extends TestCase
+final class MyPsalmTest extends TestCase
 {
     private ?PsalmTester $psalmTester = null;
 
     #[TestWith([__DIR__ . '/array_values.phpt'])]
     public function testPhptFiles(string $phptFile): void
     {
-        $skipReason = PsalmTest::getSkipReason($phptFile);
+        $skipReason = PsalmTestFixture::getSkipReason($phptFile);
 
         if ($skipReason !== null) {
             $this->markTestSkipped($skipReason);
         }
 
         $this->psalmTester ??= PsalmTester::create();
-        $this->psalmTester->test(PsalmTest::fromPhptFile($phptFile));
+        $this->psalmTester->test(PsalmTestFixture::fromPhptFile($phptFile));
     }
 }
 ```
 
 The SKIPIF script runs in a separate PHP process, so `exit()`/`die()` calls in the script do not affect the test run. `getSkipReason()` returns the reason string with the leading `skip` token stripped (e.g. `"requires PHP 8.2+"`) or `null` if the test should run.
+
+## Batch execution
+
+By default, `test()` spawns a separate Psalm process per `.phpt` file.
+For plugins with expensive boot costs (e.g., Laravel plugin boots a full application), this means each test pays the full startup overhead.
+
+`runBatch()` groups tests by their argument string and runs **one Psalm invocation per group**,
+then distributes results back to individual tests using the `file_path` field in Psalm's JSON output.
+
+```php
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use PHPyh\PsalmTester\PsalmTester;
+use PHPyh\PsalmTester\PsalmTest;
+
+final class MyPsalmTest extends TestCase
+{
+    /** @var array<string, string> */
+    private static array $batchResults = [];
+
+    /** @var array<string, PsalmTest> */
+    private static array $testData = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        $tester = PsalmTester::create(
+            defaultArguments: '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
+        );
+
+        foreach (self::discoverPhptFiles() as $name => $path) {
+            self::$testData[$name] = PsalmTest::fromPhptFile($path);
+        }
+
+        self::$batchResults = $tester->runBatch(self::$testData);
+    }
+
+    #[DataProvider('providePhptFiles')]
+    public function testPhptFiles(string $name): void
+    {
+        Assert::assertThat(
+            self::$batchResults[$name],
+            self::$testData[$name]->constraint,
+        );
+    }
+
+    // ... data provider and discovery methods
+}
+```
+
+> **Important:** Since all files in a batch group are analyzed in a single Psalm run, they share a global symbol table.
+> Ensure that class and function names are unique across `.phpt` files within the same argument group,
+> otherwise Psalm will report `DuplicateClass` / `DuplicateFunction` errors.
+
+See the source code in `PsalmTester::runBatch()` and related helper methods such as `runGroup()` for implementation details.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Trace on line %d: $_list: non-empty-list<%s>
 
 ### 2. Add a test suite
 
-`tests/PsalmTest.php`
+`tests/MyPsalmTest.php`
 
 ```php
 <?php

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -56,31 +56,144 @@ final readonly class PsalmTester
         return $temporaryDirectory;
     }
 
+    /**
+     * Run multiple tests in batched Psalm invocations (one per unique argument set).
+     * Returns formatted output per test — callers are responsible for assertions.
+     * @api
+     * @param array<string, PsalmTest> $tests keyed by identifier
+     * @return array<string, string> formatted output keyed by identifier
+     */
+    public function runBatch(array $tests): array
+    {
+        /** @var array<string, array<string, array{file: string, test: PsalmTest}>> */
+        $groups = [];
+
+        foreach ($tests as $id => $test) {
+            $args = $test->arguments ?: $this->defaultArguments;
+            $groups[$args][$id] = [
+                'file' => $this->createTemporaryCodeFile($test->code),
+                'test' => $test,
+            ];
+        }
+
+        $results = [];
+
+        foreach ($groups as $args => $entries) {
+            $results += $this->runGroup($args, $entries);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array<string, array{file: string, test: PsalmTest}> $entries
+     * @return array<string, string>
+     */
+    private function runGroup(string $args, array $entries): array
+    {
+        try {
+            $filePaths = array_map(
+                static fn(array $entry): string => $entry['file'],
+                $entries,
+            );
+
+            $output = $this->runPsalm($args, ...array_values($filePaths));
+            $decoded = $this->decodeOutput($output, $args);
+
+            /** @var array<string, list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}>> $errorsByFile */
+            $errorsByFile = [];
+            foreach ($decoded as $error) {
+                $errorsByFile[$error['file_path']][] = $error;
+            }
+
+            return array_map(function ($entry) use ($errorsByFile) {
+                return $this->formatErrors(
+                    $errorsByFile[$entry['file']] ?? [],
+                    $entry['test']->codeFirstLine,
+                );
+            }, $entries);
+        } finally {
+            foreach ($entries as $entry) {
+                @unlink($entry['file']);
+            }
+        }
+    }
+
     public function test(PsalmTest $test): void
     {
         $codeFile = $this->createTemporaryCodeFile($test->code);
 
         try {
-            $command = \sprintf(
-                '%s --output-format=json %s %s',
-                $this->psalmPath,
-                $test->arguments ?: $this->defaultArguments,
-                $codeFile,
-            );
-
-            /** @psalm-suppress ForbiddenCode */
-            $output = shell_exec($command);
-
-            if (!\is_string($output)) {
-                throw new \RuntimeException(\sprintf('Failed to run command %s.', $command));
-            }
-
-            $formattedOutput = $this->formatOutput($output, $test->codeFirstLine);
+            $args = $test->arguments ?: $this->defaultArguments;
+            $output = $this->runPsalm($args, $codeFile);
+            $decoded = $this->decodeOutput($output, $args);
+            $formattedOutput = $this->formatErrors($decoded, $test->codeFirstLine);
 
             Assert::assertThat($formattedOutput, $test->constraint);
         } finally {
             @unlink($codeFile);
         }
+    }
+
+    /**
+     * @param string $args Pre-built argument string — trusted input from $this->defaultArguments or PsalmTest::$arguments (parsed from .phpt files).
+     *                     Not escaped, as it contains multiple shell-level arguments.
+     */
+    private function runPsalm(string $args, string ...$files): string
+    {
+        $command = \sprintf(
+            '%s --output-format=json %s %s',
+            escapeshellarg($this->psalmPath),
+            $args,
+            implode(' ', array_map(escapeshellarg(...), $files)),
+        );
+
+        /** @psalm-suppress ForbiddenCode */
+        $output = shell_exec($command);
+
+        if (!\is_string($output)) {
+            throw new \RuntimeException(\sprintf('Failed to run command %s.', $command));
+        }
+
+        return $output;
+    }
+
+    /**
+     * @return list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}>
+     */
+    private function decodeOutput(string $output, string $args): array
+    {
+        try {
+            /** @var list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}> */
+            return json_decode($output, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(\sprintf(
+                "Failed to decode Psalm JSON output for args [%s]: %s\nOutput: %s",
+                $args,
+                $e->getMessage(),
+                $output,
+            ), previous: $e);
+        }
+    }
+
+    /**
+     * @param list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}> $errors
+     * @param positive-int $codeFirstLine
+     */
+    private function formatErrors(array $errors, int $codeFirstLine): string
+    {
+        /** @psalm-suppress PossiblyUndefinedStringArrayOffset */
+        usort($errors, static fn(array $a, array $b): int => $a['line_from'] <=> $b['line_from']);
+
+        return implode("\n", array_map(
+            static fn(array $error): string => \sprintf(
+                '%s on line %d: %s',
+                $error['type'],
+                $error['line_from'] + $codeFirstLine - 1,
+                $error['message'],
+            ),
+            $errors,
+        ));
     }
 
     private function createTemporaryCodeFile(string $contents): string
@@ -94,21 +207,5 @@ final readonly class PsalmTester
         file_put_contents($file, $contents);
 
         return $file;
-    }
-
-    private function formatOutput(string $output, int $codeFirstLine): string
-    {
-        /** @var list<array{type: string, column_from: int, line_from: int, message: string, ...}> */
-        $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
-
-        return implode("\n", array_map(
-            static fn(array $error): string => \sprintf(
-                '%s on line %d: %s',
-                $error['type'],
-                $error['line_from'] + $codeFirstLine - 1,
-                $error['message'],
-            ),
-            $decoded,
-        ));
     }
 }

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -67,22 +67,34 @@ final readonly class PsalmTester
     {
         /** @var array<string, array<string, array{file: string, test: PsalmTest}>> */
         $groups = [];
+        /** @var list<string> */
+        $allTempFiles = [];
 
-        foreach ($tests as $id => $test) {
-            $args = $test->arguments ?: $this->defaultArguments;
-            $groups[$args][$id] = [
-                'file' => $this->createTemporaryCodeFile($test->code),
-                'test' => $test,
-            ];
+        try {
+            foreach ($tests as $id => $test) {
+                $args = $test->arguments ?: $this->defaultArguments;
+                $file = $this->createTemporaryCodeFile($test->code);
+                $allTempFiles[] = $file;
+                $groups[$args][$id] = [
+                    'file' => $file,
+                    'test' => $test,
+                ];
+            }
+
+            $results = [];
+
+            foreach ($groups as $args => $entries) {
+                $results = array_merge($results, $this->runGroup($args, $entries));
+            }
+
+            return $results;
+        } finally {
+            foreach ($allTempFiles as $file) {
+                if (is_file($file)) {
+                    @unlink($file);
+                }
+            }
         }
-
-        $results = [];
-
-        foreach ($groups as $args => $entries) {
-            $results += $this->runGroup($args, $entries);
-        }
-
-        return $results;
     }
 
     /**

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -16,17 +16,20 @@ final readonly class PsalmTester
         private string $psalmPath,
         private string $defaultArguments,
         private string $temporaryDirectory,
+        private bool $showProgress,
     ) {}
 
     public static function create(
         ?string $psalmPath = null,
         string $defaultArguments = '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
         ?string $temporaryDirectory = null,
+        bool $showProgress = true,
     ): self {
         return new self(
             psalmPath: $psalmPath ?? self::findPsalm(),
             defaultArguments: $defaultArguments,
             temporaryDirectory: self::resolveTemporaryDirectory($temporaryDirectory),
+            showProgress: $showProgress,
         );
     }
 
@@ -84,9 +87,12 @@ final readonly class PsalmTester
             $results = [];
 
             foreach ($groups as $args => $entries) {
+                $groupCount = 0;
                 foreach ($this->runGroup($args, $entries) as $id => $output) {
                     $results[$id] = $output;
+                    $groupCount++;
                 }
+                $this->writeProgress($args, $groupCount);
             }
 
             return $results;
@@ -150,6 +156,7 @@ final readonly class PsalmTester
             $decoded = $this->decodeOutput($output, $args);
             $formattedOutput = $this->formatErrors($decoded, $test->codeFirstLine);
 
+            $this->writeProgress($args, 1);
             Assert::assertThat($formattedOutput, $test->constraint);
         } finally {
             @unlink($codeFile);
@@ -222,6 +229,14 @@ final readonly class PsalmTester
             ),
             $errors,
         ));
+    }
+
+    private function writeProgress(string $args, int $count): void
+    {
+        if ($this->showProgress) {
+            $displayArgs = \preg_replace('/\s+/', ' ', \trim($args)) ?? $args;
+            fwrite(\STDERR, \sprintf("%s: %d %s\n", $displayArgs, $count, $count === 1 ? 'test' : 'tests'));
+        }
     }
 
     private function createTemporaryCodeFile(string $contents): string

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -119,14 +119,10 @@ final readonly class PsalmTester
                 $errorsByFile[$key][] = $error;
             }
 
-            return array_map(function ($entry) use ($errorsByFile) {
-                $key = \realpath($entry['file']) ?: $entry['file'];
-
-                return $this->formatErrors(
-                    $errorsByFile[$key] ?? [],
-                    $entry['test']->codeFirstLine,
-                );
-            }, $entries);
+            return array_map(fn($entry) => $this->formatErrors(
+                $errorsByFile[\realpath($entry['file']) ?: $entry['file']] ?? [],
+                $entry['test']->codeFirstLine,
+            ), $entries);
         } finally {
             foreach ($entries as $entry) {
                 @unlink($entry['file']);

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -65,7 +65,7 @@ final readonly class PsalmTester
      */
     public function runBatch(array $tests): array
     {
-        /** @var array<string, array<string, array{file: string, test: PsalmTest}>> */
+        /** @var array<string, array<array-key, array{file: string, test: PsalmTest}>> */
         $groups = [];
         /** @var list<string> */
         $allTempFiles = [];
@@ -100,8 +100,8 @@ final readonly class PsalmTester
     }
 
     /**
-     * @param array<string, array{file: string, test: PsalmTest}> $entries
-     * @return array<string, string>
+     * @param array<array-key, array{file: string, test: PsalmTest}> $entries
+     * @return array<array-key, string>
      */
     private function runGroup(string $args, array $entries): array
     {

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -84,7 +84,9 @@ final readonly class PsalmTester
             $results = [];
 
             foreach ($groups as $args => $entries) {
-                $results = array_merge($results, $this->runGroup($args, $entries));
+                foreach ($this->runGroup($args, $entries) as $id => $output) {
+                    $results[$id] = $output;
+                }
             }
 
             return $results;
@@ -152,6 +154,10 @@ final readonly class PsalmTester
      */
     private function runPsalm(string $args, string ...$files): string
     {
+        // Collapse any whitespace (including newlines from --ARGS-- sections) to single spaces
+        // to prevent newlines from being interpreted as shell command separators.
+        $args = (string) \preg_replace('/\s+/', ' ', \trim($args));
+
         $command = \sprintf(
             '%s --output-format=json %s %s',
             escapeshellarg($this->psalmPath),

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -115,12 +115,15 @@ final readonly class PsalmTester
             /** @var array<string, list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}>> $errorsByFile */
             $errorsByFile = [];
             foreach ($decoded as $error) {
-                $errorsByFile[$error['file_path']][] = $error;
+                $key = \realpath($error['file_path']) ?: $error['file_path'];
+                $errorsByFile[$key][] = $error;
             }
 
             return array_map(function ($entry) use ($errorsByFile) {
+                $key = \realpath($entry['file']) ?: $entry['file'];
+
                 return $this->formatErrors(
-                    $errorsByFile[$entry['file']] ?? [],
+                    $errorsByFile[$key] ?? [],
                     $entry['test']->codeFirstLine,
                 );
             }, $entries);
@@ -216,7 +219,9 @@ final readonly class PsalmTester
             throw new \LogicException(\sprintf('Failed to create temporary code file in %s.', $this->temporaryDirectory));
         }
 
-        file_put_contents($file, $contents);
+        if (file_put_contents($file, $contents) === false) {
+            throw new \RuntimeException(\sprintf('Failed to write temporary code file: %s.', $file));
+        }
 
         return $file;
     }

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -72,7 +72,7 @@ final readonly class PsalmTester
 
         try {
             foreach ($tests as $id => $test) {
-                $args = $test->arguments ?: $this->defaultArguments;
+                $args = (string) \preg_replace('/\s+/', ' ', \trim($test->arguments ?: $this->defaultArguments));
                 $file = $this->createTemporaryCodeFile($test->code);
                 $allTempFiles[] = $file;
                 $groups[$args][$id] = [
@@ -121,10 +121,15 @@ final readonly class PsalmTester
                 $errorsByFile[$key][] = $error;
             }
 
-            return array_map(fn($entry) => $this->formatErrors(
-                $errorsByFile[\realpath($entry['file']) ?: $entry['file']] ?? [],
-                $entry['test']->codeFirstLine,
-            ), $entries);
+            $results = [];
+            foreach ($entries as $id => $entry) {
+                $results[$id] = $this->formatErrors(
+                    $errorsByFile[\realpath($entry['file']) ?: $entry['file']] ?? [],
+                    $entry['test']->codeFirstLine,
+                );
+            }
+
+            return $results;
         } finally {
             foreach ($entries as $entry) {
                 @unlink($entry['file']);

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -117,14 +117,17 @@ final readonly class PsalmTester
             /** @var array<string, list<array{type: string, column_from: int, line_from: int, message: string, file_path: string, ...}>> $errorsByFile */
             $errorsByFile = [];
             foreach ($decoded as $error) {
-                $key = \realpath($error['file_path']) ?: $error['file_path'];
+                $resolved = \realpath($error['file_path']);
+                $key = $resolved !== false ? $resolved : $error['file_path'];
                 $errorsByFile[$key][] = $error;
             }
 
             $results = [];
             foreach ($entries as $id => $entry) {
+                $resolved = \realpath($entry['file']);
+                $key = $resolved !== false ? $resolved : $entry['file'];
                 $results[$id] = $this->formatErrors(
-                    $errorsByFile[\realpath($entry['file']) ?: $entry['file']] ?? [],
+                    $errorsByFile[$key] ?? [],
                     $entry['test']->codeFirstLine,
                 );
             }

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -60,8 +60,8 @@ final readonly class PsalmTester
      * Run multiple tests in batched Psalm invocations (one per unique argument set).
      * Returns formatted output per test — callers are responsible for assertions.
      * @api
-     * @param array<string, PsalmTest> $tests keyed by identifier
-     * @return array<string, string> formatted output keyed by identifier
+     * @param array<array-key, PsalmTest> $tests keyed by identifier
+     * @return array<array-key, string> formatted output keyed by identifier
      */
     public function runBatch(array $tests): array
     {
@@ -200,7 +200,10 @@ final readonly class PsalmTester
     private function formatErrors(array $errors, int $codeFirstLine): string
     {
         /** @psalm-suppress PossiblyUndefinedStringArrayOffset */
-        usort($errors, static fn(array $a, array $b): int => $a['line_from'] <=> $b['line_from']);
+        usort($errors, static fn(array $a, array $b): int => ($a['line_from'] <=> $b['line_from'])
+            ?: ($a['column_from'] <=> $b['column_from'])
+            ?: ($a['type'] <=> $b['type'])
+            ?: ($a['message'] <=> $b['message']));
 
         return implode("\n", array_map(
             static fn(array $error): string => \sprintf(

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -145,7 +145,7 @@ final readonly class PsalmTester
         $codeFile = $this->createTemporaryCodeFile($test->code);
 
         try {
-            $args = $test->arguments ?: $this->defaultArguments;
+            $args = (string) \preg_replace('/\s+/', ' ', \trim($test->arguments ?: $this->defaultArguments));
             $output = $this->runPsalm($args, $codeFile);
             $decoded = $this->decodeOutput($output, $args);
             $formattedOutput = $this->formatErrors($decoded, $test->codeFirstLine);


### PR DESCRIPTION
## Summary

- Adds `runBatch(array<string, PsalmTest> $tests): array<string, string>` to `PsalmTester` — groups tests by unique CLI argument set and runs each group in a single Psalm invocation, reducing overhead from Psalm's costly initialization per call
- Refactors internal execution logic (`runGroup`, `runPsalm`, `decodeOutput`) to support multi-file invocations
- Updates README with usage example and guidelines
- Includes Rector/php-cs-fixer code quality cleanup as groundwork

## Test plan

- [ ] `runBatch()` returns formatted Psalm output keyed by test identifier
- [ ] Tests with the same args are batched into one Psalm invocation
- [ ] Tests with different args run in separate invocations
- [ ] Temporary files are cleaned up after each group runs