### PR TITLE
Add progress output: CLI args and test count per group

### DIFF
--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -16,17 +16,20 @@ final readonly class PsalmTester
         private string $psalmPath,
         private string $defaultArguments,
         private string $temporaryDirectory,
+        private bool $showProgress,
     ) {}
 
     public static function create(
         ?string $psalmPath = null,
         string $defaultArguments = '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
         ?string $temporaryDirectory = null,
+        bool $showProgress = true,
     ): self {
         return new self(
             psalmPath: $psalmPath ?? self::findPsalm(),
             defaultArguments: $defaultArguments,
             temporaryDirectory: self::resolveTemporaryDirectory($temporaryDirectory),
+            showProgress: $showProgress,
         );
     }
 
@@ -84,9 +87,12 @@ final readonly class PsalmTester
             $results = [];
 
             foreach ($groups as $args => $entries) {
+                $groupCount = 0;
                 foreach ($this->runGroup($args, $entries) as $id => $output) {
                     $results[$id] = $output;
+                    $groupCount++;
                 }
+                $this->writeProgress($args, $groupCount);
             }
 
             return $results;
@@ -150,6 +156,7 @@ final readonly class PsalmTester
             $decoded = $this->decodeOutput($output, $args);
             $formattedOutput = $this->formatErrors($decoded, $test->codeFirstLine);
 
+            $this->writeProgress($args, 1);
             Assert::assertThat($formattedOutput, $test->constraint);
         } finally {
             @unlink($codeFile);
@@ -222,6 +229,14 @@ final readonly class PsalmTester
             ),
             $errors,
         ));
+    }
+
+    private function writeProgress(string $args, int $count): void
+    {
+        if ($this->showProgress) {
+            $displayArgs = \preg_replace('/\s+/', ' ', \trim($args)) ?? $args;
+            fwrite(\STDERR, \sprintf("%s: %d %s\n", $displayArgs, $count, $count === 1 ? 'test' : 'tests'));
+        }
     }
 
     private function createTemporaryCodeFile(string $contents): string


### PR DESCRIPTION
## Summary

- Adds `showProgress: bool` parameter to `PsalmTester::create()` (default: `true`)
- On each completed group, prints one line to STDERR: `<args>: N test(s)`
- One line per unique CLI argument set — gives visibility into how tests are grouped and how many ran per invocation

Example output:
```
--no-progress --no-diff --config=.../psalm.xml: 12 tests
--no-progress --no-diff --strict-types --config=.../psalm.xml: 3 tests
```

Depends on: #4

## Test plan

- [ ] Progress lines appear on STDERR with correct args and count
- [ ] `showProgress: false` suppresses all output
- [ ] Single `test()` calls produce one line per invocation
- [ ] `runBatch()` produces one line per unique args group