### PR TITLE
Add `--SKIPIF--` section support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,46 @@ or for each test individually using `--ARGS--` section:
 --EXPECT--
 ...
 ```
+
+## Skipping tests conditionally
+
+Add a `--SKIPIF--` section containing a PHP script that echoes a message starting with `skip` when the test should not run:
+
+```phpt
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80200) { echo 'skip requires PHP 8.2+'; }
+--FILE--
+<?php
+...
+--EXPECT--
+...
+```
+
+In your test suite, call `PsalmTest::getSkipReason()` before loading the test and pass the result to PHPUnit's `markTestSkipped()`:
+
+```php
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use PHPyh\PsalmTester\PsalmTester;
+use PHPyh\PsalmTester\PsalmTest;
+
+final class PsalmTest extends TestCase
+{
+    private ?PsalmTester $psalmTester = null;
+
+    #[TestWith([__DIR__ . '/array_values.phpt'])]
+    public function testPhptFiles(string $phptFile): void
+    {
+        $skipReason = PsalmTest::getSkipReason($phptFile);
+
+        if ($skipReason !== null) {
+            $this->markTestSkipped($skipReason);
+        }
+
+        $this->psalmTester ??= PsalmTester::create();
+        $this->psalmTester->test(PsalmTest::fromPhptFile($phptFile));
+    }
+}
+```
+
+The SKIPIF script runs in a separate PHP process, so `exit()`/`die()` calls in the script do not affect the test run. `getSkipReason()` returns the reason string with the leading `skip` token stripped (e.g. `"requires PHP 8.2+"`) or `null` if the test should run.

--- a/src/PsalmTest.php
+++ b/src/PsalmTest.php
@@ -73,27 +73,26 @@ final readonly class PsalmTest
             return null;
         }
 
-        // Write the SKIPIF code to a temp file so that require handles <?php correctly.
+        // Execute the SKIPIF script in a separate PHP process so that die()/exit() calls
+        // in the script do not terminate the current test run.
         $tempFile = \tempnam(\sys_get_temp_dir(), 'psalm_skipif_');
 
         if ($tempFile === false) {
             return null;
         }
 
-        \file_put_contents($tempFile, $sections[self::SKIPIF][0]);
+        if (\file_put_contents($tempFile, $sections[self::SKIPIF][0]) === false) {
+            \unlink($tempFile);
 
-        \ob_start();
+            return null;
+        }
 
         try {
-            // Isolate the require to avoid polluting the current scope.
-            (static function (string $file): void {
-                require $file;
-            })($tempFile);
+            /** @psalm-suppress ForbiddenCode */
+            $output = \trim((string) \shell_exec(\PHP_BINARY . ' ' . \escapeshellarg($tempFile)));
         } finally {
             \unlink($tempFile);
         }
-
-        $output = \trim(\ob_get_clean() ?: '');
 
         if (\stripos($output, 'skip') === 0) {
             return $output;

--- a/src/PsalmTest.php
+++ b/src/PsalmTest.php
@@ -62,8 +62,8 @@ final readonly class PsalmTest
      *   --SKIPIF--
      *   <?php if (PHP_VERSION_ID < 80200) { echo 'skip requires PHP 8.2+'; }
      *
-     * Returns null when no SKIPIF section is present or when the section's output
-     * does not start with "skip".
+     * Returns the reason string with the leading "skip" token stripped (e.g. "requires PHP 8.2+"),
+     * or null when no SKIPIF section is present or the output does not start with "skip".
      */
     public static function getSkipReason(string $phptFile): ?string
     {
@@ -89,13 +89,13 @@ final readonly class PsalmTest
 
         try {
             /** @psalm-suppress ForbiddenCode */
-            $output = \trim((string) \shell_exec(\PHP_BINARY . ' ' . \escapeshellarg($tempFile)));
+            $output = \trim((string) \shell_exec(\escapeshellarg(\PHP_BINARY) . ' ' . \escapeshellarg($tempFile)));
         } finally {
             \unlink($tempFile);
         }
 
         if (\stripos($output, 'skip') === 0) {
-            return $output;
+            return \ltrim(\substr($output, 4));
         }
 
         return null;

--- a/src/PsalmTest.php
+++ b/src/PsalmTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
  */
 final readonly class PsalmTest
 {
+    private const SKIPIF = 'SKIPIF';
     private const FILE = 'FILE';
     private const ARGS = 'ARGS';
     private const EXPECT = 'EXPECT';
@@ -49,6 +50,56 @@ final readonly class PsalmTest
             arguments: $sections[self::ARGS][0] ?? '',
             codeFirstLine: $sections[self::FILE][1],
         );
+    }
+
+    /**
+     * Evaluate the --SKIPIF-- section of a .phpt file and return the skip reason,
+     * or null if the test should not be skipped.
+     *
+     * The SKIPIF section contains a PHP script (starting with <?php) that echoes
+     * a message beginning with "skip" when the test should be skipped, e.g.:
+     *
+     *   --SKIPIF--
+     *   <?php if (PHP_VERSION_ID < 80200) { echo 'skip requires PHP 8.2+'; }
+     *
+     * Returns null when no SKIPIF section is present or when the section's output
+     * does not start with "skip".
+     */
+    public static function getSkipReason(string $phptFile): ?string
+    {
+        $sections = self::parsePhpt($phptFile);
+
+        if (!isset($sections[self::SKIPIF])) {
+            return null;
+        }
+
+        // Write the SKIPIF code to a temp file so that require handles <?php correctly.
+        $tempFile = \tempnam(\sys_get_temp_dir(), 'psalm_skipif_');
+
+        if ($tempFile === false) {
+            return null;
+        }
+
+        \file_put_contents($tempFile, $sections[self::SKIPIF][0]);
+
+        \ob_start();
+
+        try {
+            // Isolate the require to avoid polluting the current scope.
+            (static function (string $file): void {
+                require $file;
+            })($tempFile);
+        } finally {
+            \unlink($tempFile);
+        }
+
+        $output = \trim(\ob_get_clean() ?: '');
+
+        if (\stripos($output, 'skip') === 0) {
+            return $output;
+        }
+
+        return null;
     }
 
     /**

--- a/src/PsalmTest.php
+++ b/src/PsalmTest.php
@@ -78,13 +78,13 @@ final readonly class PsalmTest
         $tempFile = \tempnam(\sys_get_temp_dir(), 'psalm_skipif_');
 
         if ($tempFile === false) {
-            return null;
+            throw new \RuntimeException(\sprintf('Failed to create temporary file for SKIPIF evaluation of %s.', $phptFile));
         }
 
         if (\file_put_contents($tempFile, $sections[self::SKIPIF][0]) === false) {
             \unlink($tempFile);
 
-            return null;
+            throw new \RuntimeException(\sprintf('Failed to write temporary SKIPIF file for %s.', $phptFile));
         }
 
         try {


### PR DESCRIPTION
## Summary

- Adds `--SKIPIF--` section support to `.phpt` files, following standard PHP test (`qa.php.net/phpt_details.php`) behavior
- New `PsalmTest::getSkipReason(string $phptContent): ?string` static method evaluates the SKIPIF script and returns the skip reason string, or `null` if the test should run
- `fromPhptFile()` now recognises and ignores the `SKIPIF` section, so existing parsers don't reject files that include it

Usage:
```phpt
--SKIPIF--
<?php if (PHP_VERSION_ID < 80200) { echo 'skip requires PHP 8.2+'; }
--FILE--
...
```

```php
$skipReason = PsalmTest::getSkipReason($phptContent);
if ($skipReason !== null) {
    $this->markTestSkipped($skipReason);
}
$test = PsalmTest::fromPhptFile($phptContent);
```

## Test plan

- [ ] `getSkipReason()` returns `null` when SKIPIF section is absent
- [ ] `getSkipReason()` returns `null` when SKIPIF script outputs nothing starting with `skip`
- [ ] `getSkipReason()` returns the skip message when script echoes `skip ...`
- [ ] `fromPhptFile()` parses files with `SKIPIF` section without error