### PR TITLE
feat: isolate cache dir per concurrent batch group

### DIFF
--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -200,7 +200,7 @@ final readonly class PsalmTester
      */
     private static function buildChildEnv(string $cacheDir): array
     {
-        $env = \getenv();
+        $env = \getenv() ?: [];
         $env['XDG_CACHE_HOME'] = $cacheDir;
         $env['TMPDIR'] = $cacheDir;
         $env['TMP'] = $cacheDir;
@@ -215,18 +215,24 @@ final readonly class PsalmTester
             return;
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST,
-        );
+        // Best-effort cleanup: this runs from runBatch's finally, so an iterator
+        // failure here must not mask the original exception.
+        try {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            );
 
-        foreach ($iterator as $entry) {
-            /** @var \SplFileInfo $entry */
-            if ($entry->isDir() && !$entry->isLink()) {
-                @\rmdir($entry->getPathname());
-            } else {
-                @\unlink($entry->getPathname());
+            foreach ($iterator as $entry) {
+                /** @var \SplFileInfo $entry */
+                if ($entry->isDir() && !$entry->isLink()) {
+                    @\rmdir($entry->getPathname());
+                } else {
+                    @\unlink($entry->getPathname());
+                }
             }
+        } catch (\UnexpectedValueException) {
+            return;
         }
 
         @\rmdir($dir);

--- a/src/PsalmTester.php
+++ b/src/PsalmTester.php
@@ -92,19 +92,22 @@ final readonly class PsalmTester
                 $results[$id] = '';
             }
 
-            /** @var array<int, array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, process: resource, stdout: ?resource, stderr: ?resource, stdoutBuffer: string}> */
+            /** @var array<int, array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, cacheDir: string, process: resource, stdout: ?resource, stderr: ?resource, stdoutBuffer: string}> */
             $running = [];
+            /** @var list<string> */
+            $allCacheDirs = [];
 
             try {
                 foreach ($groups as $args => $entries) {
-                    $running[] = $this->startGroup($args, $entries);
+                    $proc = $this->startGroup($args, $entries);
+                    $allCacheDirs[] = $proc['cacheDir'];
+                    $running[] = $proc;
                 }
 
                 $this->drainAndFinalize($running, $results);
 
                 return $results;
             } finally {
-                // Ensure any leftover processes (unreached in the success path) are cleaned up on exception.
                 foreach ($running as $proc) {
                     if ($proc['stdout'] !== null) {
                         @\fclose($proc['stdout']);
@@ -113,6 +116,9 @@ final readonly class PsalmTester
                         @\fclose($proc['stderr']);
                     }
                     @\proc_close($proc['process']);
+                }
+                foreach ($allCacheDirs as $dir) {
+                    self::removeDirectoryRecursive($dir);
                 }
             }
         } finally {
@@ -126,7 +132,7 @@ final readonly class PsalmTester
 
     /**
      * @param array<array-key, array{file: string, test: PsalmTest}> $entries
-     * @return array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, process: resource, stdout: resource, stderr: resource, stdoutBuffer: string}
+     * @return array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, cacheDir: string, process: resource, stdout: resource, stderr: resource, stdoutBuffer: string}
      */
     private function startGroup(string $args, array $entries): array
     {
@@ -142,15 +148,23 @@ final readonly class PsalmTester
             \implode(' ', array_map(\escapeshellarg(...), array_values($filePaths))),
         );
 
+        // Point Psalm and any plugins at a per-group scratch dir so concurrent groups
+        // don't race on a shared cache location. XDG_CACHE_HOME is what Psalm itself
+        // reads; TMPDIR/TMP/TEMP cover plugins that derive their cache from
+        // sys_get_temp_dir() (e.g. psalm-plugin-laravel's Plugin::getCacheLocation()).
+        $cacheDir = $this->createGroupCacheDir();
+        $env = self::buildChildEnv($cacheDir);
+
         $descriptors = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
             2 => ['pipe', 'w'],
         ];
         $pipes = [];
-        $process = \proc_open($command, $descriptors, $pipes);
+        $process = \proc_open($command, $descriptors, $pipes, null, $env);
 
         if (!\is_resource($process)) {
+            self::removeDirectoryRecursive($cacheDir);
             throw new \RuntimeException(\sprintf('Failed to run command %s.', $command));
         }
 
@@ -162,6 +176,7 @@ final readonly class PsalmTester
             'args' => $args,
             'entries' => $entries,
             'command' => $command,
+            'cacheDir' => $cacheDir,
             'process' => $process,
             'stdout' => $pipes[1],
             'stderr' => $pipes[2],
@@ -169,8 +184,56 @@ final readonly class PsalmTester
         ];
     }
 
+    private function createGroupCacheDir(): string
+    {
+        $dir = $this->temporaryDirectory . '/cache_' . \bin2hex(\random_bytes(8));
+
+        if (!\mkdir($dir, 0777, true) && !\is_dir($dir)) {
+            throw new \RuntimeException(\sprintf('Failed to create per-group cache directory %s.', $dir));
+        }
+
+        return $dir;
+    }
+
     /**
-     * @param array<int, array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, process: resource, stdout: ?resource, stderr: ?resource, stdoutBuffer: string}> $running
+     * @return array<string, string>
+     */
+    private static function buildChildEnv(string $cacheDir): array
+    {
+        $env = \getenv();
+        $env['XDG_CACHE_HOME'] = $cacheDir;
+        $env['TMPDIR'] = $cacheDir;
+        $env['TMP'] = $cacheDir;
+        $env['TEMP'] = $cacheDir;
+
+        return $env;
+    }
+
+    private static function removeDirectoryRecursive(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $entry) {
+            /** @var \SplFileInfo $entry */
+            if ($entry->isDir() && !$entry->isLink()) {
+                @\rmdir($entry->getPathname());
+            } else {
+                @\unlink($entry->getPathname());
+            }
+        }
+
+        @\rmdir($dir);
+    }
+
+    /**
+     * @param array<int, array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, cacheDir: string, process: resource, stdout: ?resource, stderr: ?resource, stdoutBuffer: string}> $running
      * @param array<array-key, string> $results
      * @param-out array<array-key, string> $results
      */
@@ -235,7 +298,7 @@ final readonly class PsalmTester
     }
 
     /**
-     * @param array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, process: resource, stdout: ?resource, stderr: ?resource, stdoutBuffer: string} $proc
+     * @param array{args: string, entries: array<array-key, array{file: string, test: PsalmTest}>, command: string, cacheDir: string, process: resource, stdout: ?resource, stderr: ?resource, stdoutBuffer: string} $proc
      * @param array<array-key, string> $results
      * @param-out array<array-key, string> $results
      */

--- a/tests/PsalmTesterBatchTest.php
+++ b/tests/PsalmTesterBatchTest.php
@@ -182,13 +182,21 @@ final class PsalmTesterBatchTest extends TestCase
             self::assertCount(3, \array_unique($xdg), 'XDG_CACHE_HOME must differ across groups.');
             self::assertCount(3, \array_unique($tmpdir), 'TMPDIR must differ across groups.');
 
+            // sys_get_temp_dir() honors TMPDIR unless php.ini's sys_temp_dir is set,
+            // in which case it ignores the env var entirely. Only assert the
+            // end-to-end override when sys_temp_dir is unset.
+            $sysTempDirIniSet = (string) \ini_get('sys_temp_dir') !== '';
+
             foreach ($records as $record) {
                 self::assertNotSame('', $record['XDG_CACHE_HOME']);
                 self::assertSame($record['XDG_CACHE_HOME'], $record['TMPDIR']);
                 self::assertSame($record['XDG_CACHE_HOME'], $record['TMP']);
                 self::assertSame($record['XDG_CACHE_HOME'], $record['TEMP']);
-                self::assertSame($record['XDG_CACHE_HOME'], $record['sys_get_temp_dir']);
                 self::assertStringStartsWith(\sys_get_temp_dir() . '/psalm_test/cache_', $record['XDG_CACHE_HOME']);
+
+                if (!$sysTempDirIniSet) {
+                    self::assertSame($record['XDG_CACHE_HOME'], $record['sys_get_temp_dir']);
+                }
             }
 
             self::assertSame(

--- a/tests/PsalmTesterBatchTest.php
+++ b/tests/PsalmTesterBatchTest.php
@@ -18,6 +18,7 @@ final class PsalmTesterBatchTest extends TestCase
     {
         \putenv('STUB_SLEEP');
         \putenv('STUB_MODE');
+        \putenv('STUB_ENV_LOG_DIR');
     }
 
     public function testRunBatchPreservesInputOrderAndDistributesErrorsAcrossGroups(): void
@@ -145,6 +146,74 @@ final class PsalmTesterBatchTest extends TestCase
         // typical OS pipe buffer (16-64KB). Each error maps to one output line.
         $lineCount = \substr_count($results['big'], "\n") + 1;
         self::assertSame(3000, $lineCount);
+    }
+
+    public function testRunBatchGivesEachGroupIsolatedCacheDirAndCleansUp(): void
+    {
+        $tester = self::createTester();
+
+        $logDir = \sys_get_temp_dir() . '/psalm_tester_env_log_' . \bin2hex(\random_bytes(4));
+        self::assertTrue(\mkdir($logDir, 0777, true));
+
+        $scratchRootBefore = self::listScratchCacheDirs();
+
+        try {
+            \putenv('STUB_MODE=env_record');
+            \putenv('STUB_ENV_LOG_DIR=' . $logDir);
+
+            $tester->runBatch([
+                'a' => new PsalmTest(code: '<?php // a', constraint: new IsIdentical(''), arguments: '--config=a'),
+                'b' => new PsalmTest(code: '<?php // b', constraint: new IsIdentical(''), arguments: '--config=b'),
+                'c' => new PsalmTest(code: '<?php // c', constraint: new IsIdentical(''), arguments: '--config=c'),
+            ]);
+
+            /** @var list<array{XDG_CACHE_HOME: string, TMPDIR: string, TMP: string, TEMP: string, sys_get_temp_dir: string}> $records */
+            $records = [];
+            foreach (\glob($logDir . '/*.json') ?: [] as $file) {
+                /** @var array{XDG_CACHE_HOME: string, TMPDIR: string, TMP: string, TEMP: string, sys_get_temp_dir: string} $decoded */
+                $decoded = \json_decode((string) \file_get_contents($file), true, flags: \JSON_THROW_ON_ERROR);
+                $records[] = $decoded;
+            }
+
+            self::assertCount(3, $records, 'Each group should invoke the stub exactly once.');
+
+            $xdg = \array_column($records, 'XDG_CACHE_HOME');
+            $tmpdir = \array_column($records, 'TMPDIR');
+            self::assertCount(3, \array_unique($xdg), 'XDG_CACHE_HOME must differ across groups.');
+            self::assertCount(3, \array_unique($tmpdir), 'TMPDIR must differ across groups.');
+
+            foreach ($records as $record) {
+                self::assertNotSame('', $record['XDG_CACHE_HOME']);
+                self::assertSame($record['XDG_CACHE_HOME'], $record['TMPDIR']);
+                self::assertSame($record['XDG_CACHE_HOME'], $record['TMP']);
+                self::assertSame($record['XDG_CACHE_HOME'], $record['TEMP']);
+                self::assertSame($record['XDG_CACHE_HOME'], $record['sys_get_temp_dir']);
+                self::assertStringStartsWith(\sys_get_temp_dir() . '/psalm_test/cache_', $record['XDG_CACHE_HOME']);
+            }
+
+            self::assertSame(
+                $scratchRootBefore,
+                self::listScratchCacheDirs(),
+                'Per-group cache dirs must be cleaned up after runBatch returns.',
+            );
+        } finally {
+            foreach (\glob($logDir . '/*.json') ?: [] as $file) {
+                @\unlink($file);
+            }
+            @\rmdir($logDir);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function listScratchCacheDirs(): array
+    {
+        /** @var list<string> $dirs */
+        $dirs = \glob(\sys_get_temp_dir() . '/psalm_test/cache_*', \GLOB_ONLYDIR) ?: [];
+        \sort($dirs);
+
+        return $dirs;
     }
 
     private static function createTester(string $defaultArguments = ''): PsalmTester

--- a/tests/bin/psalm-stub
+++ b/tests/bin/psalm-stub
@@ -18,6 +18,26 @@ if ($mode === 'invalid_json') {
     exit(0);
 }
 
+if ($mode === 'env_record') {
+    $logDir = (string) \getenv('STUB_ENV_LOG_DIR');
+    if ($logDir !== '' && \is_dir($logDir)) {
+        $payload = [
+            'pid' => \getmypid(),
+            'XDG_CACHE_HOME' => (string) \getenv('XDG_CACHE_HOME'),
+            'TMPDIR' => (string) \getenv('TMPDIR'),
+            'TMP' => (string) \getenv('TMP'),
+            'TEMP' => (string) \getenv('TEMP'),
+            'sys_get_temp_dir' => \sys_get_temp_dir(),
+        ];
+        \file_put_contents(
+            $logDir . '/' . \getmypid() . '_' . \bin2hex(\random_bytes(4)) . '.json',
+            (string) \json_encode($payload),
+        );
+    }
+    \fwrite(\STDOUT, '[]');
+    exit(0);
+}
+
 /** @var list<string> $files */
 $files = [];
 foreach (\array_slice($argv, 1) as $arg) {


### PR DESCRIPTION
## Summary

Fixes #7.

Each group launched by `runBatch` now gets its own scratch directory, passed to the Psalm child process via `XDG_CACHE_HOME` and `TMPDIR`/`TMP`/`TEMP`.

- `XDG_CACHE_HOME` isolates Psalm's own cache (Psalm falls back to `\$XDG_CACHE_HOME/psalm` before `sys_get_temp_dir()/psalm`, per `Config::loadFromXMLFile`).
- `TMPDIR` (plus `TMP`/`TEMP` for parity) isolates plugin caches derived from `sys_get_temp_dir()`, e.g. `Psalm\LaravelPlugin\Plugin::getCacheLocation()` in psalm-plugin-laravel.

The dir is removed in the `runBatch` finally block on both success and failure.

## Why

Under the parallel runner (ce21007), concurrent Psalm invocations shared the same plugin cache path and raced on a non-safe `mkdir()` in the Laravel plugin, causing:

```
PHP Error: mkdir(): File exists in src/Plugin.php:697
Next ConfigException: Failed to invoke plugin Psalm\LaravelPlugin\Plugin
```

Any plugin with the same pattern would break. We fix this in psalm-tester rather than requiring every plugin to be race-safe.

## Tests

Added `testRunBatchGivesEachGroupIsolatedCacheDirAndCleansUp`: extends the stub with an `env_record` mode, runs 3 groups, asserts each child saw a distinct `XDG_CACHE_HOME`/`TMPDIR` and that all per-group dirs are removed after `runBatch` returns.